### PR TITLE
Fix sorting order

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -26,7 +26,7 @@ if (isset($_SESSION['valid']) && $_SESSION['valid']) {
     }
     $start_count = $limit * ($page - 1);
 
-    $query_name = "SELECT * FROM $mytable ORDER BY date DESC LIMIT $start_count,$limit";
+    $query_name = "SELECT * FROM $mytable ORDER BY ID DESC LIMIT $start_count,$limit";
     $results_name = $base->query($query_name);
 
     echo '<h1>My snippets</h1><div id="newSnippet">';

--- a/index.php
+++ b/index.php
@@ -32,11 +32,11 @@
     
     // if logged in, the user can see the private snippets
     if(isset($_SESSION['valid']) && $_SESSION['valid']){
-        $query_name = "SELECT * FROM $mytable ORDER BY date DESC LIMIT $start_count,$limit";
+        $query_name = "SELECT * FROM $mytable ORDER BY ID DESC LIMIT $start_count,$limit";
     }
     // if not logged in, select only public snippets
     else {
-        $query_name = "SELECT * FROM $mytable WHERE private != 'on' ORDER BY date DESC LIMIT $start_count,$limit";
+        $query_name = "SELECT * FROM $mytable WHERE private != 'on' ORDER BY ID DESC LIMIT $start_count,$limit";
     }
     $results_name = $base->query($query_name);
     


### PR DESCRIPTION
It is not possible to order by date given the current storage format
(text formatted by PHP's date("F j, Y - H:i") function)

This patch is a first fix for existing installations to order snippets
by ID (which is autoincrementing).

Another patch that will follow aim to additionnaly store the date in
an ISO 8601 format.
