### PR TITLE
Fix the format used to store the date

### DIFF
--- a/admin/action.php
+++ b/admin/action.php
@@ -134,7 +134,7 @@ if (isset($_POST["add"])) {
 
     $code = $_POST['code'];
     $private = (isset($_POST['private']) && $_POST['private'] = "on")?"on":"off";
-    $date = date("F j, Y - H:i");
+    $date = date("Y-m-d H:i:s");
     // connect to the database
     $dbname = '../snippets.sqlite';
     $mytable = "snippets";

--- a/install.php
+++ b/install.php
@@ -104,7 +104,7 @@ if (file_exists($config["dbname"])) {
                 description longtext,
                 name longtext,
                 code longtext,
-                date date,
+                date text,
                 private integer
                 )";
             $base->exec($createSnippetsDatabase);


### PR DESCRIPTION
Store the date as ISO 8601 YYYY-MM-DD HH:MM:SS string

There is no true DATE type in SQLite (http://www.sqlite.org/datatype3.html)

```
SQLite does not have a storage class set aside for storing dates and/or times. 
Instead, the built-in Date And Time Functions of SQLite are capable of storing 
dates and times as TEXT, REAL, or INTEGER values:

    TEXT as ISO8601 strings ("YYYY-MM-DD HH:MM:SS.SSS").
    REAL as Julian day numbers, the number of days since noon in Greenwich 
    on November 24, 4714 B.C. according to the proleptic Gregorian calendar.
    INTEGER as Unix Time, the number of seconds since 1970-01-01 00:00:00 UTC. 

Applications can chose to store dates and times in any of these formats and 
freely convert between formats using the built-in date and time functions.
```

I think ISO8601 strings are in our case a good balance between readability and usefulness.
